### PR TITLE
Add support for cleaning up commands run as SYSTEM

### DIFF
--- a/Invoke-CommandAs.psm1
+++ b/Invoke-CommandAs.psm1
@@ -323,7 +323,7 @@ function Invoke-CommandAs {
 
             If ($ScheduledTask) {
                 Write-Verbose "Unregister ScheduledTask"
-                #Try { $ScheduledTask | Unregister-ScheduledTask -Confirm:$False } Catch {}
+                Try { $ScheduledTask | Unregister-ScheduledTask -Confirm:$False } Catch {}
             }
 
             If ($ScheduledJob) {

--- a/Invoke-CommandAs.psm1
+++ b/Invoke-CommandAs.psm1
@@ -323,7 +323,10 @@ function Invoke-CommandAs {
 
             If ($ScheduledTask) {
                 Write-Verbose "Unregister ScheduledTask"
+                # For Windows 8 / Server 2012 and Newer
                 Try { $ScheduledTask | Unregister-ScheduledTask -Confirm:$False } Catch {}
+                # For Windows 7 / Server 2008 R2
+                Try { $ScheduleTaskFolder.DeleteTask($ScheduledTask.Name, 0) | Out-Null } Catch {}
             }
 
             If ($ScheduledJob) {


### PR DESCRIPTION
It appears that work was already done to allow for cleanup of scheduled tasks but was commented out. These changes allow for those tasks to be removed, as currently they are left behind.