### PR TITLE
Update Invoke-ScheduledTask.ps1

### DIFF
--- a/Invoke-CommandAs/Private/Invoke-ScheduledTask.ps1
+++ b/Invoke-CommandAs/Private/Invoke-ScheduledTask.ps1
@@ -26,7 +26,10 @@ function Invoke-ScheduledTask {
             $JobParameters = @{ }
             $JobParameters['Name'] = $JobName
             If ($RunElevated.IsPresent) {
-                $JobParameters['ScheduledJobOption'] = New-ScheduledJobOption -RunElevated
+                $JobParameters['ScheduledJobOption'] = New-ScheduledJobOption -RunElevated -StartIfOnBattery -ContinueIfGoingOnBattery
+            }
+            Else {
+                $JobParameters['ScheduledJobOption'] = New-ScheduledJobOption -StartIfOnBattery -ContinueIfGoingOnBattery
             }
 
             $JobArgumentList = @{ }


### PR DESCRIPTION
Updated Invoke-ScheduledTask.ps1 to add "-StartIfOnBattery -ContinueIfGoingOnBattery" parameters to New-ScheduledJobOption

Default behavior of scheduled tasks is to start when on AC power, causing Invoke-CommandAs to silently fail when run on a system running on battery power.

Added 'StartIfOnBattery' to allow scheduled tasks to run when on battery power, and 'ContinueIfGoingOnBattery' to allow for long-running script blocks to continue running after transitioning from AC to battery power.
