### PR TITLE
Fix issue #51

### DIFF
--- a/Invoke-CommandAs/Private/Invoke-ScheduledTask.ps1
+++ b/Invoke-CommandAs/Private/Invoke-ScheduledTask.ps1
@@ -90,6 +90,7 @@ function Invoke-ScheduledTask {
                     Write-Verbose "$(Get-Date): ScheduledTask: Register"
                     $TaskParameters = @{ TaskName = $ScheduledJob.Name }
                     $TaskParameters['Action'] = New-ScheduledTaskAction -Execute $ScheduledJob.PSExecutionPath -Argument $ScheduledJob.PSExecutionArgs
+                    $TaskParameters['Settings'] = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
                     If ($AsSystem) {
                         $TaskParameters['Principal'] = New-ScheduledTaskPrincipal -UserID "NT AUTHORITY\SYSTEM" -LogonType ServiceAccount -RunLevel Highest
                     } ElseIf ($AsGMSA) {


### PR DESCRIPTION
The last pull request by hartleyj fixed running on battery power when running as a job, but not when running as a task, so it still didn't work for running with -AsSsytem, -AsInteractive, -AsUser, or -AsGMSA. Fixed that by adding a New-ScheduledTaskSettingsSet to $TaskParameters and setting -AllowStartIfOnBatteries and -DontStopIfGoingOnBatteries.