### PR TITLE
Scheduled job can't run for local accounts

### DIFF
--- a/Invoke-CommandAs/Private/Invoke-ScheduledTask.ps1
+++ b/Invoke-CommandAs/Private/Invoke-ScheduledTask.ps1
@@ -23,8 +23,10 @@ function Invoke-ScheduledTask {
 
         Try {
 
-            $JobParameters = @{ }
-            $JobParameters['Name'] = $JobName
+            $JobParameters = @{
+                Name = $JobName
+            }
+            If ($AsUser) { $JobParameters['Credential'] = $AsUser}
             If ($RunElevated.IsPresent) {
                 $JobParameters['ScheduledJobOption'] = New-ScheduledJobOption -RunElevated -StartIfOnBattery -ContinueIfGoingOnBattery
             }
@@ -32,7 +34,10 @@ function Invoke-ScheduledTask {
                 $JobParameters['ScheduledJobOption'] = New-ScheduledJobOption -StartIfOnBattery -ContinueIfGoingOnBattery
             }
 
-            $JobArgumentList = @{ }
+
+            $JobArgumentList = @{
+                Using = @()
+            }
             If ($ScriptBlock)  { $JobArgumentList['ScriptBlock']  = $ScriptBlock }
             If ($ArgumentList) { $JobArgumentList['ArgumentList'] = $ArgumentList }
 
@@ -42,7 +47,6 @@ function Invoke-ScheduledTask {
             # Inspired by Boe Prox, and his https://github.com/proxb/PoshRSJob module
             #      and by Warren Framem and his https://github.com/RamblingCookieMonster/Invoke-Parallel module
 
-            $JobArgumentList['Using'] = @()
             $UsingVariables = $ScriptBlock.ast.FindAll({$args[0] -is [System.Management.Automation.Language.UsingExpressionAst]},$True)
             If ($UsingVariables) {
 
@@ -77,7 +81,7 @@ function Invoke-ScheduledTask {
 "@)
 
             Write-Verbose "$(Get-Date): ScheduledJob: Register"
-            $ScheduledJob = Register-ScheduledJob  @JobParameters -ScriptBlock $JobScriptBlock -ArgumentList $JobArgumentList -ErrorAction Stop
+            $ScheduledJob = Register-ScheduledJob @JobParameters -ScriptBlock $JobScriptBlock -ArgumentList $JobArgumentList -ErrorAction Stop
 
             If ($AsSystem -or $AsInteractive -or $AsUser -or $AsGMSA) {
 


### PR DESCRIPTION
I discovered when trying to run a script block with `-AsUser`, where the credential is a *local user account*\*, the scheduled job just wouldn't run. powershell.exe would return with an exit code 1 from task scheduler.

Code example is below to repro, however it's important you use a local, non-domain joined, account for the cred.

```powershell
$cred = Get-Credential
Invoke-CommandAs -ScriptBlock { whoami } -AsUser $cred
```

It doesn't seem to be an issue for domain accounts, and I don't know enough about Windows like this to rationalise it. However, through debugging I did find once I passed the `-RunAs` credential to the `Register-ScheduledJob` in `Invoke-ScheduledTask`, the scheduled job would be successfully invoked by task scheduler.

\* In order to get a local user account to work, you will need to grant the local user account `SeBatchLogonRight` rights, [more info](https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/user-rights-assignment). Can be configured locally w/o GPO using secpol.msc:

![image](https://user-images.githubusercontent.com/6683266/234087104-a8a56ad9-debe-42b2-a409-20f03baabf5c.png)

As an aside, I did a minor cleanup in `Invoke-ScheduledTask` to initialise a couple of hashtables with a value, rather than initialising the hashtables and then defining values in them - no reason other than "meh".